### PR TITLE
Use spring.factories and application.properties

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ public class MyMojo extends AbstractMojo {
 You want to use a class that implements Helloer interface, coming from a spring library.
 
 #### 1. Add the extension
-You should add this extension in the `extensions.xml` file located in your maven config folder `.mvn`. Like below.    
+You should add this extension in the `extensions.xml` file located in your maven config folder `.mvn` of your application (the one that uses the custom plugin). Like below.    
 ```xml
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0"...>
 	<extension>
@@ -40,27 +40,23 @@ You should add this extension in the `extensions.xml` file located in your maven
 You can see how to use extensions in more details [here](https://maven.apache.org/guides/mini/guide-using-extensions.html).  
   
 #### 2. Add a configuration file
-Create one like below  
+In the custom plugin, create `spring.factories` like below (in `src/main/resources/META-INF` folder) 
 ```properties
-spring-ext.groupId=com.homeofthewizard
-spring-ext.artifactId=friends-lib
-spring-ext.version=1.0-SNAPSHOT
-spring-ext.contextConfigClass=com.homeofthewizard.friends.MySpringConfiguration
+com.homeofthewizard.SpringBootPlugin=com.homeofthewizard.friends.MySpringConfiguration
+```
+As you can guess, this defines the configuration sources for the the spring application context to be used in the plugin. You can specify a class with `@EnableAutoConfiguration` annotation, or just a plain `@Configuration` class.
 
+Also create an `application.properties` file like below
+```properties
 friend.name=Bob
 ```
 
-As you can guess, the first tree properties are for defining the spring library to be used.   
-The forth is the spring configuration class that will be used to initialise the spring context, and create the beans we need.  
+This is the spring configuration class that will be used to initialise the spring context, and create the beans we need.  
 :warning: pay attention to the prefix used for those properties.  
 The rest of the properties are specific to the spring library we use. Here our library takes a property as parameter to create our `Friend` Bean.  
 
-Place it under `src/main/resources` folder. this is the default place the extension will look up.    
-You can change the path if you want, but you will need to precise the path via a system variable when running maven commands.
-```shell
-mvn .... -Dspring-ext.configFilePath=/home/user/workspace/myPlugin/spring-ext.properties
-```
-  
+Place these under `src/main/resources` folder. This is the default place the extension will look up.    
+
 #### 3. Add the extension as a dependency of your plugin
 This is necessary for classpath sharing.  
 In your plugin's `pom.xml`  
@@ -68,10 +64,10 @@ In your plugin's `pom.xml`
     ...
     <dependencies>
         ...
-        <!-- the extension -->
+        <!-- the extension library -->
         <dependency>
             <groupId>com.homeofthewizard</groupId>
-            <artifactId>spring-bridge-maven-extension</artifactId>
+            <artifactId>spring-bridge-maven-library</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <!-- our spring library -->

--- a/library/src/main/java/com/homeofthewizard/PropertyBasedConfigurableSpringModule.java
+++ b/library/src/main/java/com/homeofthewizard/PropertyBasedConfigurableSpringModule.java
@@ -1,73 +1,34 @@
 package com.homeofthewizard;
 
 import java.io.IOException;
-import java.util.Properties;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.inject.Named;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.core.env.PropertySource;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.UrlResource;
-import org.springframework.core.io.support.PropertiesLoaderUtils;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.guice.module.SpringModule;
-import org.springframework.util.StringUtils;
 
 @Named
 class PropertyBasedConfigurableSpringModule extends SpringModule {
 
-    private final static String SPRING_EXT = "spring-ext";
-    private final static String CONFIG_FILE_PATH = SPRING_EXT + "." + "configFilePath";
-    private final static String CONTEXT_CONFIG_CLASS = SPRING_EXT + "." + "contextConfigClass";
-    private final static String SPRING_MAVEN_EXTENSION_PROPERTIES = "SpringMavenExtensionProperties";
-    private final static String DEFAULT_PROPERTIES_FILE_PATH = SPRING_EXT + ".properties";
-    private final static Properties properties = new Properties();
-
-    static {
-        loadProperties();
-    }
-
-    static void loadProperties() {
-        try {
-            var path = StringUtils.cleanPath(System.getProperty(CONFIG_FILE_PATH, DEFAULT_PROPERTIES_FILE_PATH));
-            var resource = path.equals(DEFAULT_PROPERTIES_FILE_PATH)
-                    ? new ClassPathResource(DEFAULT_PROPERTIES_FILE_PATH,
-                            PropertyBasedConfigurableSpringModule.class.getClassLoader())
-                    : path.contains(":") ? new UrlResource(System.getProperty(CONFIG_FILE_PATH))
-                            : new FileSystemResource(path);
-            PropertiesLoaderUtils.fillProperties(properties, resource);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
-    }
-
     public PropertyBasedConfigurableSpringModule()
             throws ClassNotFoundException, IOException {
-        super(new SpringApplicationBuilder()
-                .sources(loadSpringConfigClass())
-                .initializers(context -> context
-                        .getEnvironment()
-                        .getPropertySources()
-                        .addLast(new SpringExtensionPropertySource(SPRING_MAVEN_EXTENSION_PROPERTIES)))
-                .run());
+        super(new SpringApplicationBuilder(new DefaultResourceLoader(PropertyBasedConfigurableSpringModule.class.getClassLoader()))
+                .sources(loadSpringConfigClass()).run());
     }
 
-    static private Class<?> loadSpringConfigClass()
+    static private Class<?>[] loadSpringConfigClass()
             throws ClassNotFoundException, IOException {
         var classLoader = PropertyBasedConfigurableSpringModule.class.getClassLoader();
-        return classLoader.loadClass(properties.getProperty(CONTEXT_CONFIG_CLASS));
+        List<String> names = SpringFactoriesLoader.loadFactoryNames(SpringBootPlugin.class, classLoader);
+        List<Class<?>> types = new ArrayList<>();
+        for (String name : names) {
+            types.add(classLoader.loadClass(name));
+        }
+        return types.toArray(new Class<?>[0]);
     }
 
-    private static class SpringExtensionPropertySource extends PropertySource<String> {
-        public SpringExtensionPropertySource(String name) {
-            super(name);
-        }
-
-        @Override
-        public Object getProperty(String name) {
-            return properties.getProperty(name);
-        }
-    }
 }

--- a/library/src/main/java/com/homeofthewizard/SpringBootPlugin.java
+++ b/library/src/main/java/com/homeofthewizard/SpringBootPlugin.java
@@ -1,0 +1,16 @@
+package com.homeofthewizard;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface SpringBootPlugin {
+	Class<?>[] value() default {};
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,6 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <properties>
-                                <spring-ext.configFilePath>${project.build.directory}/it/example/plugin/src/main/resources/spring-ext.properties</spring-ext.configFilePath>
-                            </properties>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <streamLogs>true</streamLogs>
                         </configuration>

--- a/src/it/example/plugin/src/main/java/com/homeofthewizard/plugin/MyMojo.java
+++ b/src/it/example/plugin/src/main/java/com/homeofthewizard/plugin/MyMojo.java
@@ -3,11 +3,14 @@ package com.homeofthewizard.plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import com.homeofthewizard.SpringBootPlugin;
 import com.homeofthewizard.friends.MyHelloer;
+import com.homeofthewizard.friends.MySpringConfiguration;
 
 import javax.inject.Inject;
 
 @Mojo(name = "run", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@SpringBootPlugin(MySpringConfiguration.class)
 public class MyMojo extends AbstractMojo {
 
     private final MyHelloer myFriend;

--- a/src/it/example/plugin/src/main/resources/META-INF/spring.factories
+++ b/src/it/example/plugin/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+com.homeofthewizard.SpringBootPlugin=\
+com.homeofthewizard.friends.MySpringConfiguration

--- a/src/it/example/plugin/src/main/resources/application.properties
+++ b/src/it/example/plugin/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+friend.name=Bob
+

--- a/src/it/example/plugin/src/main/resources/spring-ext.properties
+++ b/src/it/example/plugin/src/main/resources/spring-ext.properties
@@ -1,3 +1,0 @@
-spring-ext.contextConfigClass=com.homeofthewizard.friends.MySpringConfiguration
-friend.name=Bob
-


### PR DESCRIPTION
The `@SpringBootPlugin` annotation is just cosmetic right now -
everything is loaded from spring.factories - but that could
be generated at build time if we add that feature (similar to
how Sisu works).

I couldn't find a way to scan the `@Mojo` for additional 
annotations at runtime - you only find out about it much too
late (after the Guice injector is created).